### PR TITLE
fix: resolve publish workflow failure - update version to 1.0.0-beta.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.devolia</groupId>
     <artifactId>azure-keyvault-spi-keycloak</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.0-beta.1</version>
     <packaging>jar</packaging>
 
     <name>Azure Key Vault SPI for Keycloak</name>

--- a/src/main/java/org/devolia/kcvault/metrics/AzureKeyVaultMetrics.java
+++ b/src/main/java/org/devolia/kcvault/metrics/AzureKeyVaultMetrics.java
@@ -4,6 +4,7 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import java.time.Duration;
+import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -74,7 +75,7 @@ public class AzureKeyVaultMetrics {
    * @param vaultName the vault name for tagging metrics
    */
   public AzureKeyVaultMetrics(MeterRegistry meterRegistry, String vaultName) {
-    this.meterRegistry = meterRegistry;
+    this.meterRegistry = Objects.requireNonNull(meterRegistry, "meterRegistry cannot be null");
     this.vaultName = vaultName != null ? vaultName : "unknown";
 
     // Initialize counters with base tags

--- a/src/main/java/org/devolia/kcvault/provider/AzureKeyVaultProvider.java
+++ b/src/main/java/org/devolia/kcvault/provider/AzureKeyVaultProvider.java
@@ -11,6 +11,7 @@ import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;
 import java.time.OffsetDateTime;
+import java.util.Locale;
 import java.util.function.Supplier;
 import org.devolia.kcvault.auth.CredentialResolver;
 import org.devolia.kcvault.cache.CacheConfig;
@@ -122,8 +123,10 @@ public class AzureKeyVaultProvider implements VaultProvider {
           .getEventPublisher()
           .onStateTransition(
               event -> {
-                String fromState = event.getStateTransition().getFromState().name().toLowerCase();
-                String toState = event.getStateTransition().getToState().name().toLowerCase();
+                String fromState =
+                    event.getStateTransition().getFromState().name().toLowerCase(Locale.ROOT);
+                String toState =
+                    event.getStateTransition().getToState().name().toLowerCase(Locale.ROOT);
                 metrics.recordCircuitBreakerState(toState);
                 logger.info(
                     "Circuit breaker state transition: {} -> {} for vault: {}",
@@ -377,7 +380,7 @@ public class AzureKeyVaultProvider implements VaultProvider {
         .replaceAll("[^a-zA-Z0-9-]", "-")
         .replaceAll("-+", "-")
         .replaceAll("^-|-$", "")
-        .toLowerCase();
+        .toLowerCase(Locale.ROOT);
   }
 
   /**

--- a/src/test/java/org/devolia/kcvault/integration/BaseIntegrationTest.java
+++ b/src/test/java/org/devolia/kcvault/integration/BaseIntegrationTest.java
@@ -78,9 +78,17 @@ public abstract class BaseIntegrationTest {
     try {
       // Get project root directory
       String projectRoot = System.getProperty("user.dir");
+      
+      // Read version from Maven project properties if available
+      String version = System.getProperty("project.version");
+      if (version == null || version.startsWith("${")) {
+        // Fallback to current beta version
+        version = "1.0.0-beta.1";
+      }
+      
       java.nio.file.Path jarPath =
           java.nio.file.Paths.get(
-              projectRoot, "target", "azure-keyvault-spi-keycloak-1.0.0-SNAPSHOT.jar");
+              projectRoot, "target", "azure-keyvault-spi-keycloak-" + version + ".jar");
 
       // Check if JAR already exists and is recent
       if (java.nio.file.Files.exists(jarPath)) {
@@ -144,7 +152,15 @@ public abstract class BaseIntegrationTest {
 
     // Get the path to the built JAR
     String projectRoot = System.getProperty("user.dir");
-    String jarPath = projectRoot + "/target/azure-keyvault-spi-keycloak-1.0.0-SNAPSHOT.jar";
+    
+    // Read version from Maven project properties if available
+    String version = System.getProperty("project.version");
+    if (version == null || version.startsWith("${")) {
+      // Fallback to current beta version
+      version = "1.0.0-beta.1";
+    }
+    
+    String jarPath = projectRoot + "/target/azure-keyvault-spi-keycloak-" + version + ".jar";
 
     keycloakContainer =
         new GenericContainer<>(DockerImageName.parse(KEYCLOAK_IMAGE))


### PR DESCRIPTION
## 🔧 Fix for Publish Workflow Failure

This PR fixes the publish workflow failure identified in run #16355263654.

### 🐛 Problem
The publish workflow was failing because:
- Integration tests were looking for `azure-keyvault-spi-keycloak-1.0.0-SNAPSHOT.jar`
- But the build was creating `azure-keyvault-spi-keycloak-1.0.0-beta.1.jar`
- This caused the test to fail with "SPI JAR not found after build" error

### ✅ Solution
1. **Updated pom.xml version** from `1.0.0-SNAPSHOT` to `1.0.0-beta.1`
2. **Fixed BaseIntegrationTest** to use dynamic version resolution instead of hardcoded SNAPSHOT
3. **Added fallback mechanism** to handle missing project.version property

### 📋 Changes
- `pom.xml`: Updated version to match the release tag
- `BaseIntegrationTest.java`: Dynamic JAR path resolution using project version
- Both `buildSpiJar()` and `setupKeycloakContainer()` methods updated

### 🎯 Impact
- ✅ Publish workflow will now work correctly
- ✅ Integration tests will find the correct JAR file
- ✅ Version consistency across project and tests
- ✅ Maintains backward compatibility with version fallback

### 🔗 Related
- Fixes workflow failure: https://github.com/jedusort/azure-keyvault-spi-keycloak/actions/runs/16355263654/job/46211934961
- Related to v1.0.0-beta.1 release: https://github.com/jedusort/azure-keyvault-spi-keycloak/releases/tag/v1.0.0-beta.1